### PR TITLE
[Feat] Update Table Load / Add IntroScene

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -25,8 +25,23 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 29c74e3467f738e43848fbd68756821b
+    m_Address: "\uC6A9\uC625"
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 3e873f5e50027024791f768c9de8ec42
     m_Address: C003_sprite
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 5372ed5b56a17e245b96d0c08e49b0ff
+    m_Address: "\uB3C4\uC804\uC7A5"
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 8f26f150d582b654a93ce15670391979
+    m_Address: "\uCD08\uB300\uC7A5"
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
@@ -37,6 +52,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: a5d2a344b6432b849b7a858204643c76
     m_Address: Gray2
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: acd4c241c8df3da4da3ec0c879bd40db
+    m_Address: "\uB4F1\uC6A9\uD328"
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/Assets/PersonalWorkplace/BIK/Prefabs/CurrencyUI.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/CurrencyUI.prefab
@@ -303,3 +303,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 1
   _currencyText: {fileID: 8624420201437250817}
+  _currencyImage: {fileID: 728956521747808137}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}

--- a/Assets/PersonalWorkplace/BIK/Prefabs/ItemSlot.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/ItemSlot.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 91767855092267831}
   - component: {fileID: 3068035994004653741}
   - component: {fileID: 9108130683792319275}
+  - component: {fileID: 508755718287444430}
   m_Layer: 5
   m_Name: ItemSlot
   m_TagString: Untagged
@@ -77,6 +78,20 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &508755718287444430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522528622813048050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fc4ce3722eb89240b5c4fb004577f95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _itemImage: {fileID: 464853263173877174}
+  _itemAmount: {fileID: 6399987055438766221}
 --- !u!1 &8484572227135758326
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/PersonalWorkplace/BIK/Prefabs/MainSceneCanvas.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/MainSceneCanvas.prefab
@@ -3903,7 +3903,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4014430143730306557, guid: b81ab7b672b20a34abf5372da7da3000, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4064937850714554799, guid: b81ab7b672b20a34abf5372da7da3000, type: 3}
       propertyPath: m_AnchorMax.y
@@ -3967,7 +3967,7 @@ PrefabInstance:
       objectReference: {fileID: 4301342812065383193}
     - target: {fileID: 7324431714763885037, guid: b81ab7b672b20a34abf5372da7da3000, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: -1575
       objectReference: {fileID: 0}
     - target: {fileID: 7687962625462714113, guid: b81ab7b672b20a34abf5372da7da3000, type: 3}
       propertyPath: heroUI

--- a/Assets/PersonalWorkplace/BIK/Prefabs/PopupCanvas.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/PopupCanvas.prefab
@@ -34,6 +34,7 @@ RectTransform:
   m_Children:
   - {fileID: 5415670594037027949}
   - {fileID: 4669817497071117775}
+  - {fileID: 5389135636870489665}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -116,7 +117,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d7d0d29340394c4ca581c9dfc9fc4c3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _popupEntries: []
+  _popupEntries:
+  - popupType: 0
+    uiBase: {fileID: 0}
+  - popupType: 0
+    uiBase: {fileID: 0}
+  - popupType: 2
+    uiBase: {fileID: 2163450201655400560}
 --- !u!1001 &7405988536801465559
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -624,4 +631,121 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3504596880106220874, guid: 8e86b622136204c42a4ff1e81cae1b3b, type: 3}
   m_PrefabInstance: {fileID: 8902077135988422951}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8919519969878713391
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6244843987079543999}
+    m_Modifications:
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6540733977631065007, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_Name
+      value: TooltipPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 6540733977631065007, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+--- !u!114 &2163450201655400560 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7335974949690375263, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+  m_PrefabInstance: {fileID: 8919519969878713391}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19ef546d7e89fa646a50737371957596, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5389135636870489665 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3531541638252839534, guid: 17569d682b399fe4bb53fb62e2f15595, type: 3}
+  m_PrefabInstance: {fileID: 8919519969878713391}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/PersonalWorkplace/BIK/Prefabs/TooltipPanel.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/TooltipPanel.prefab
@@ -1,0 +1,767 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4194454130197276978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3044555428340659630}
+  - component: {fileID: 1303527139248896463}
+  - component: {fileID: 8292241441583495265}
+  m_Layer: 5
+  m_Name: Text ItemName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3044555428340659630
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4194454130197276978}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1027407758518119699}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &1303527139248896463
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4194454130197276978}
+  m_CullTransparentMesh: 1
+--- !u!114 &8292241441583495265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4194454130197276978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC6A9\uC625"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ada6d14095912444d949013d0728dfef, type: 2}
+  m_sharedMaterial: {fileID: 7863189952179728171, guid: ada6d14095912444d949013d0728dfef, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5392353175832553236
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2425120633922777505}
+  - component: {fileID: 4881507361193135152}
+  - component: {fileID: 8607951563912807393}
+  m_Layer: 5
+  m_Name: TooltipBG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2425120633922777505
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5392353175832553236}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 453257754647856914}
+  - {fileID: 1027407758518119699}
+  - {fileID: 3910091345867040583}
+  m_Father: {fileID: 3531541638252839534}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 50, y: 50}
+  m_SizeDelta: {x: 900, y: 1000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4881507361193135152
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5392353175832553236}
+  m_CullTransparentMesh: 1
+--- !u!114 &8607951563912807393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5392353175832553236}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 8e7a71b0ae6995b438e17d75539859e6, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5879536024797557336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3910091345867040583}
+  - component: {fileID: 6829346593224291961}
+  - component: {fileID: 2647203503968062336}
+  m_Layer: 5
+  m_Name: Text Explane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3910091345867040583
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5879536024797557336}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425120633922777505}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -200}
+  m_SizeDelta: {x: 700, y: 500}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6829346593224291961
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5879536024797557336}
+  m_CullTransparentMesh: 1
+--- !u!114 &2647203503968062336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5879536024797557336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC774 \uC544\uC774\uD15C\uC740 \uC5B4\uB5BB\uAC8C \uC0AC\uC6A9\uD558\uB294\uC9C0
+    \uC124\uBA85\uC5D0 \uAD00\uD55C \uD14D\uC2A4\uD2B8\uB97C \uC801\uC744 \uC608\uC815"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ada6d14095912444d949013d0728dfef, type: 2}
+  m_sharedMaterial: {fileID: 7863189952179728171, guid: ada6d14095912444d949013d0728dfef, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 30
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6038889065423840445
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 453257754647856914}
+  - component: {fileID: 7032595328134462834}
+  - component: {fileID: 1892859153447591826}
+  - component: {fileID: 4251805173832615918}
+  m_Layer: 5
+  m_Name: Button Close
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &453257754647856914
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6038889065423840445}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2425120633922777505}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 10, y: 10}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &7032595328134462834
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6038889065423840445}
+  m_CullTransparentMesh: 1
+--- !u!114 &1892859153447591826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6038889065423840445}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -5833179248954492752, guid: 2cb030761133bf94c9cbb74aadf69d17, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4251805173832615918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6038889065423840445}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1892859153447591826}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7335974949690375263}
+        m_TargetAssemblyTypeName: UIBase, Assembly-CSharp
+        m_MethodName: SetHide
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &6540733977631065007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3531541638252839534}
+  - component: {fileID: 2759850242662390195}
+  - component: {fileID: 3017177094401251569}
+  - component: {fileID: 7335974949690375263}
+  m_Layer: 5
+  m_Name: TooltipPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3531541638252839534
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540733977631065007}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2425120633922777505}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2759850242662390195
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540733977631065007}
+  m_CullTransparentMesh: 1
+--- !u!114 &3017177094401251569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540733977631065007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7335974949690375263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6540733977631065007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19ef546d7e89fa646a50737371957596, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _itemSlot: {fileID: 3031524184158005125}
+  _itemName: {fileID: 8292241441583495265}
+  _itemExplane: {fileID: 2647203503968062336}
+--- !u!1 &6668985721822652469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1027407758518119699}
+  - component: {fileID: 1025977441398072702}
+  - component: {fileID: 1219090154000152690}
+  m_Layer: 5
+  m_Name: Image ItemBG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1027407758518119699
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6668985721822652469}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3196240644663432572}
+  - {fileID: 3044555428340659630}
+  m_Father: {fileID: 2425120633922777505}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -74}
+  m_SizeDelta: {x: 700, y: 300}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1025977441398072702
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6668985721822652469}
+  m_CullTransparentMesh: 1
+--- !u!114 &1219090154000152690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6668985721822652469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b5a3c7a7bd853344f90c830db09cc49f, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &3250848575835778635
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1027407758518119699}
+    m_Modifications:
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1522528622813048050, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+      propertyPath: m_Name
+      value: ItemSlot
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+--- !u!114 &3031524184158005125 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 508755718287444430, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+  m_PrefabInstance: {fileID: 3250848575835778635}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0fc4ce3722eb89240b5c4fb004577f95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3196240644663432572 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 91767855092267831, guid: 98a8b2dfb2da18c489145fb3738e3d2f, type: 3}
+  m_PrefabInstance: {fileID: 3250848575835778635}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/PersonalWorkplace/BIK/Prefabs/TooltipPanel.prefab.meta
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/TooltipPanel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17569d682b399fe4bb53fb62e2f15595
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PersonalWorkplace/BIK/Prefabs/TopUI.prefab
+++ b/Assets/PersonalWorkplace/BIK/Prefabs/TopUI.prefab
@@ -109,6 +109,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 6
   _currencyText: {fileID: 5042027493629573105}
+  _currencyImage: {fileID: 9051874854515886737}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &464712478814450213
 GameObject:
   m_ObjectHideFlags: 0
@@ -761,6 +763,7 @@ GameObject:
   - component: {fileID: 4791394501966129902}
   - component: {fileID: 1754481688967133956}
   - component: {fileID: 6485461281852348696}
+  - component: {fileID: 8403305012358606765}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -826,6 +829,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8403305012358606765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2723327195965761850}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6485461281852348696}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7303393126783584792}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2908323745915169168
 GameObject:
   m_ObjectHideFlags: 0
@@ -981,6 +1040,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 1
   _currencyText: {fileID: 3936506251767617231}
+  _currencyImage: {fileID: 8318393783267739606}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &3890747297849953689
 GameObject:
   m_ObjectHideFlags: 0
@@ -1165,6 +1226,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 2
   _currencyText: {fileID: 5664616565524833682}
+  _currencyImage: {fileID: 3762523676592224587}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &4097130418553378670
 GameObject:
   m_ObjectHideFlags: 0
@@ -1176,6 +1239,7 @@ GameObject:
   - component: {fileID: 2157000259123707658}
   - component: {fileID: 6246897179839347580}
   - component: {fileID: 6674252597217138646}
+  - component: {fileID: 4797736764738532685}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -1241,6 +1305,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4797736764738532685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4097130418553378670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6674252597217138646}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3539434270374106791}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &4175365151280735716
 GameObject:
   m_ObjectHideFlags: 0
@@ -1368,6 +1488,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 4
   _currencyText: {fileID: 1845915974261543735}
+  _currencyImage: {fileID: 8001349066838206102}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &4375646360757997330
 GameObject:
   m_ObjectHideFlags: 0
@@ -1627,6 +1749,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 5
   _currencyText: {fileID: 4490853111426955886}
+  _currencyImage: {fileID: 879497323430296162}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &4769206159570165502
 GameObject:
   m_ObjectHideFlags: 0
@@ -2677,6 +2801,7 @@ GameObject:
   - component: {fileID: 5006578545717369813}
   - component: {fileID: 4841699673579013543}
   - component: {fileID: 8259617862004158173}
+  - component: {fileID: 6710301786257021023}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -2742,6 +2867,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6710301786257021023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5312244826931846732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8259617862004158173}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6647093527054995799}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &5328234054447996456
 GameObject:
   m_ObjectHideFlags: 0
@@ -3307,6 +3488,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1677628793927017819}
+  - component: {fileID: 9067329749202442100}
   m_Layer: 0
   m_Name: CurrencyThings
   m_TagString: Untagged
@@ -3338,6 +3520,27 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 1, y: 1}
+--- !u!114 &9067329749202442100
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6334979326745193676}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39a45514a102dcd4eb8466ddb05cdcf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mainCurrencyUI: {fileID: 3919477292755741890}
+  _currencyUIs:
+  - {fileID: 1721254465491227792}
+  - {fileID: 3539434270374106791}
+  - {fileID: 6407661359025214935}
+  - {fileID: 5525705047801058154}
+  - {fileID: 6278990923921296548}
+  - {fileID: 7303393126783584792}
+  - {fileID: 6647093527054995799}
 --- !u!1 &7068000322023119030
 GameObject:
   m_ObjectHideFlags: 0
@@ -3390,6 +3593,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 3
   _currencyText: {fileID: 1168057881546644804}
+  _currencyImage: {fileID: 3633802033199223440}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &7938998599932427266
 GameObject:
   m_ObjectHideFlags: 0
@@ -3401,6 +3606,7 @@ GameObject:
   - component: {fileID: 8082603510101728958}
   - component: {fileID: 3331602541153036469}
   - component: {fileID: 2872680593135333420}
+  - component: {fileID: 4410557323271656991}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -3466,6 +3672,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4410557323271656991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7938998599932427266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2872680593135333420}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6407661359025214935}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8043515786864283347
 GameObject:
   m_ObjectHideFlags: 0
@@ -3613,6 +3875,7 @@ GameObject:
   - component: {fileID: 7616053969835629773}
   - component: {fileID: 4023963796401256904}
   - component: {fileID: 2672856912405111464}
+  - component: {fileID: 1698505291191933779}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -3678,6 +3941,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1698505291191933779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8346369124028679238}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2672856912405111464}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6278990923921296548}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8362482146093272234
 GameObject:
   m_ObjectHideFlags: 0
@@ -3825,6 +4144,7 @@ GameObject:
   - component: {fileID: 5157669611928410463}
   - component: {fileID: 2017749687566800022}
   - component: {fileID: 2851764664297696854}
+  - component: {fileID: 1624121554929827442}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -3890,6 +4210,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1624121554929827442
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8481052273105916329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2851764664297696854}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5525705047801058154}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &8556070651778923844
 GameObject:
   m_ObjectHideFlags: 0
@@ -4281,6 +4657,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _targetCurrency: 0
   _currencyText: {fileID: 2478189609922832400}
+  _currencyImage: {fileID: 206145348351104396}
+  _config: {fileID: 11400000, guid: 5911fb78ac549a54aba804cb3cc8dd53, type: 2}
 --- !u!1 &8983488058188709853
 GameObject:
   m_ObjectHideFlags: 0
@@ -4292,6 +4670,7 @@ GameObject:
   - component: {fileID: 6759085580081175715}
   - component: {fileID: 4407669561628378034}
   - component: {fileID: 4149332140590080268}
+  - component: {fileID: 2113465114714061567}
   m_Layer: 5
   m_Name: Image CurrencyBG
   m_TagString: Untagged
@@ -4357,6 +4736,62 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &2113465114714061567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8983488058188709853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4149332140590080268}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1721254465491227792}
+        m_TargetAssemblyTypeName: CurrencyUI, Assembly-CSharp
+        m_MethodName: OnClick_Text
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1001 &7322889309825936500
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4572,6 +5007,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 57fde5bcc9a3614498a628848223f084, type: 3}
+--- !u!114 &3919477292755741890 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4666603121812603371, guid: 57fde5bcc9a3614498a628848223f084, type: 3}
+  m_PrefabInstance: {fileID: 8550045428391144745}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bfa30eba3e4c344ca5fa7082a4e9061, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &4363047201983523077 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5344494386590352428, guid: 57fde5bcc9a3614498a628848223f084, type: 3}

--- a/Assets/PersonalWorkplace/BIK/Scenes/DEMO_GameScene.unity
+++ b/Assets/PersonalWorkplace/BIK/Scenes/DEMO_GameScene.unity
@@ -21597,6 +21597,8 @@ MonoBehaviour:
   playerCount: 0
   isBossDead: 0
   isStartReady: 0
+  alignPoint: {fileID: 0}
+  surface: {fileID: 0}
   stagetext: {fileID: 0}
 --- !u!4 &1331494749
 Transform:
@@ -21830,6 +21832,78 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3788503044816492023, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4193576562105628469, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4197471050078835651, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5292245517313644694, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -21890,6 +21964,42 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5556231116146110523, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5556231116146110523, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5556231116146110523, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5597524615883682181, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5948048485023271002, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -21912,6 +22022,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5948048485023271002, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6079228226564220920, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}
+      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6424562576714379179, guid: f08a535853c3eb94db7873c0288f8cf8, type: 3}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Curruncy/GameLifetimeScope.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Curruncy/GameLifetimeScope.cs
@@ -10,10 +10,8 @@ public class GameLifetimeScope : LifetimeScope
     protected override void Awake()
     {
         DontDestroyOnLoad(gameObject);
-        FirebaseApp.CheckAndFixDependenciesAsync().ContinueWithOnMainThread(task =>
-        {
-            if (task.Result == DependencyStatus.Available)
-            {
+        FirebaseApp.CheckAndFixDependenciesAsync().ContinueWithOnMainThread(task => {
+            if (task.Result == DependencyStatus.Available) {
                 FirebaseApp app = FirebaseApp.DefaultInstance;
                 app.Options.DatabaseUrl = new System.Uri("https://cheonmyungmuhwa-d3fc4-default-rtdb.asia-southeast1.firebasedatabase.app");
 
@@ -36,5 +34,8 @@ public class GameLifetimeScope : LifetimeScope
         builder.RegisterEntryPoint<PlayerProfileManager>(Lifetime.Singleton);
         // 영웅정보
         builder.RegisterEntryPoint<HeroDataManager>(Lifetime.Singleton);
+
+        // 테이블
+        builder.RegisterEntryPoint<TableManager>(Lifetime.Singleton).AsSelf();
     }
 }

--- a/Assets/PersonalWorkplace/BIK/Scripts/IntroSceneManager.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/IntroSceneManager.cs
@@ -1,0 +1,39 @@
+using Firebase;
+using Firebase.Extensions;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using VContainer;
+using VContainer.Unity;
+
+public class IntroSceneManager : MonoBehaviour
+{
+    [SerializeField] private string _mainSceneName = "DEMO_GameScene";
+
+    private IEnumerator Start()
+    {
+        var dependencyTask = FirebaseApp.CheckAndFixDependenciesAsync();
+        yield return new WaitUntil(() => dependencyTask.IsCompleted);
+
+        if (dependencyTask.Result != DependencyStatus.Available) {
+            Debug.LogError($"Firebase 초기화 실패: {dependencyTask.Result}");
+            yield break;
+        }
+
+        var scope = FindObjectOfType<GameLifetimeScope>();
+        if (scope != null) {
+            yield return new WaitUntil(() => scope.Container != null);
+        }
+
+        if (scope != null) {
+            var tableManager = scope.Container.Resolve<TableManager>();
+
+            // AllInitialized == true 될 때까지 기다리기
+            yield return new WaitUntil(() => tableManager.AllInitialized);
+
+            Debug.Log("[IntroScene] 모든 테이블 로딩 완료!");
+        }
+
+        SceneManager.LoadScene(_mainSceneName);
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/IntroSceneManager.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/IntroSceneManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 46cb4a93b28a4d74d97406648d27de0e

--- a/Assets/PersonalWorkplace/BIK/Scripts/PlayModeStartFromIntro.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/PlayModeStartFromIntro.cs
@@ -1,0 +1,45 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class PlayModeStartFromIntro
+{
+    private const string IntroScenePath = "Assets/Scenes/IntroScene.unity";
+    private const string MenuName = "Tools/Always Start From IntroScene";
+
+    private static bool _enabled;
+
+    static PlayModeStartFromIntro()
+    {
+        _enabled = EditorPrefs.GetBool(MenuName, true);
+        SetPlayModeStartScene(_enabled);
+
+        // 메뉴 아이템 상태 반영
+        EditorApplication.delayCall += () => {
+            Menu.SetChecked(MenuName, _enabled);
+        };
+    }
+
+    [MenuItem(MenuName)]
+    private static void Toggle()
+    {
+        _enabled = !_enabled;
+        EditorPrefs.SetBool(MenuName, _enabled);
+        Menu.SetChecked(MenuName, _enabled);
+        SetPlayModeStartScene(_enabled);
+    }
+
+    private static void SetPlayModeStartScene(bool enabled)
+    {
+        if (enabled) {
+            var sceneAsset = AssetDatabase.LoadAssetAtPath<SceneAsset>(IntroScenePath);
+            EditorSceneManager.playModeStartScene = sceneAsset;
+        }
+        else {
+            EditorSceneManager.playModeStartScene = null;
+        }
+    }
+}
+#endif

--- a/Assets/PersonalWorkplace/BIK/Scripts/PlayModeStartFromIntro.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/PlayModeStartFromIntro.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cc51da54a4c4bb4b8d8fa8b0db5fcd5

--- a/Assets/PersonalWorkplace/BIK/Scripts/SceneInjectionHandler.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/SceneInjectionHandler.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using VContainer.Unity;
+
+public class SceneInjectionHandler : MonoBehaviour
+{
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        var scope = LifetimeScope.Find<GameLifetimeScope>();
+        if (scope == null) return;
+
+        foreach (var ui in Object.FindObjectsOfType<CurrencyUI>(true)) {
+            scope.Container.Inject(ui);
+        }
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/SceneInjectionHandler.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/SceneInjectionHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a65a4d715b239d342836652866e50123

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0da1d1d15547674e86c7cac8ff05516
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/CurrencyConfig.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/CurrencyConfig.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "CurrencyConfig", menuName = "Configs/CurrencyConfig")]
+public class CurrencyConfig : ScriptableObject
+{
+    [Serializable]
+    public class Entry
+    {
+        public CurrencyType type;
+        public int itemId;
+    }
+
+    [SerializeField] private List<Entry> _entries = new();
+
+    private Dictionary<CurrencyType, int> _map;
+
+    private void OnEnable()
+    {
+        _map = new Dictionary<CurrencyType, int>();
+        foreach (var e in _entries)
+            _map[e.type] = e.itemId;
+    }
+
+    public int GetItemId(CurrencyType type)
+    {
+        return _map.TryGetValue(type, out var id) ? id : -1;
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/CurrencyConfig.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/CurrencyConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72d31b90e956efe47aa47215e8060561

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/ITable.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/ITable.cs
@@ -1,0 +1,5 @@
+public interface ITable
+{
+    bool IsInitialized { get; }
+    void Load(string url);
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/ITable.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/ITable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4bd69bf37b27584cb8f397933c3fd88

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TItem.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TItem.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class TItem : ITable
+{
+    private Dictionary<int, ItemData> _items = new();
+
+    public bool IsInitialized { get; private set; } = false;
+
+    public event Action OnLoaded; // 로딩 완료 이벤트
+
+    public void Load(string url)
+    {
+        CoroutineRunner.instance.StartCoroutine(LoadFromSheet(url));
+    }
+
+    private IEnumerator LoadFromSheet(string url)
+    {
+        using var req = UnityWebRequest.Get(url);
+        yield return req.SendWebRequest();
+
+        if (req.result == UnityWebRequest.Result.Success) {
+            ParseCSV(req.downloadHandler.text);
+            IsInitialized = true;
+            OnLoaded?.Invoke();
+        }
+        else {
+            Debug.LogError("ItemTable load failed: " + req.error);
+        }
+    }
+
+    private void ParseCSV(string csv)
+    {
+        var lines = csv.Split('\n');
+
+        for (int i = 1; i < lines.Length; i++) // 0번째 줄은 무조건 건너뜀
+        {
+            if (string.IsNullOrWhiteSpace(lines[i])) continue;
+            var cols = lines[i].Split(',');
+            if (cols.Length < 6) continue;
+
+            if (!int.TryParse(cols[0].Trim(), out int id)) {
+                Debug.LogWarning($"[ParseCSV] 잘못된 ID 값: {cols[0]} (line {i})");
+                continue;
+            }
+
+            string name = cols[1].Trim();
+            string detail = cols[2].Trim();
+            string imageKey = cols[3].Trim();
+
+            string stackStr = cols[4].Trim().ToLower();
+            bool stackable = stackStr == "1" || stackStr == "true";
+
+            ItemType type = Enum.TryParse(cols[5].Trim(), true, out ItemType parsedType)
+                ? parsedType
+                : ItemType.None;
+
+            var item = new ItemData(id, name, detail, imageKey, stackable, type);
+            _items[id] = item;
+        }
+    }
+
+
+    public ItemData GetItem(int id)
+    {
+        return _items.TryGetValue(id, out var data) ? data : null;
+    }
+
+    public string GetIconKey(int id)
+    {
+        return _items.TryGetValue(id, out var data) ? data.ImageKey : null;
+    }
+}
+
+public class ItemData
+{
+    public int Id { get; }                 // Item_ID
+    public string Name { get; }            // Item_Name
+    public string Detail { get; }          // Item_Detail (아이템 설명)
+    public string ImageKey { get; }        // Item_Image (어드레서블 키나 리소스 경로)
+    public bool Stackable { get; }         // Item_Stackable (true/false)
+    public ItemType Type { get; }          // Item_Type (enum으로 관리 추천)
+
+    public ItemData(
+        int id,
+        string name,
+        string detail,
+        string imageKey,
+        bool stackable,
+        ItemType type)
+    {
+        Id = id;
+        Name = name;
+        Detail = detail;
+        ImageKey = imageKey;
+        Stackable = stackable;
+        Type = type;
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TItem.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f852294aa3dfcd418e7b32254365b66

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TableConfig.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TableConfig.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TableConfig", menuName = "Configs/TableConfig")]
+public class TableConfig : ScriptableObject
+{
+    [Serializable]
+    public class TableEntry
+    {
+        public TableType type;
+        public string sheetUrl;
+    }
+
+    [SerializeField] private List<TableEntry> _tables = new();
+
+    private static TableConfig _instance;
+    public static TableConfig Instance {
+        get {
+            if (_instance == null)
+                _instance = Resources.Load<TableConfig>("TableConfig");
+            return _instance;
+        }
+    }
+
+    public string GetUrl(TableType type)
+    {
+        foreach (var entry in _tables)
+            if (entry.type == type)
+                return entry.sheetUrl;
+        return null;
+    }
+
+    public List<TableEntry> GetAll() => _tables;
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TableConfig.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TableConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 144c2e9449d6432468d763183a70fb8c

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TableManager.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TableManager.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.AppUI.UI;
+using UnityEngine;
+using VContainer;
+using VContainer.Unity;
+
+public class TableManager : IStartable
+{
+    private readonly Dictionary<TableType, ITable> _tables = new();
+
+    public bool AllInitialized {
+        get {
+            foreach (var kv in _tables)
+                if (!kv.Value.IsInitialized)
+                    return false;
+            return true;
+        }
+    }
+
+    public void Start()
+    {
+        LoadAllTables();
+    }
+
+    private void LoadAllTables()
+    {
+        var all = TableConfig.Instance.GetAll();
+        Debug.Log($"[TableManager] LoadAllTables: config count = {all.Count}");
+
+        foreach (var entry in all) {
+            Debug.Log($"[TableManager] entry: {entry.type}, url={entry.sheetUrl}");
+            ITable table = CreateTable(entry.type);
+            if (table == null) {
+                Debug.LogWarning($"[TableManager] {entry.type} 테이블 클래스 미구현");
+                continue;
+            }
+
+            // 1) 딕셔너리에 먼저 넣고
+            _tables[entry.type] = table;
+
+            try {
+                // 2) 그 다음 Load (예외 나도 _tables는 유지)
+                table.Load(entry.sheetUrl);
+            }
+            catch (System.Exception e) {
+                Debug.LogError($"[TableManager] {entry.type} Load() 예외: {e}");
+            }
+        }
+
+        Debug.Log($"[TableManager] after loop, _tables.Count = {_tables.Count}");
+    }
+
+
+    private ITable CreateTable(TableType type)
+    {
+        return type switch {
+            TableType.Item => new TItem(), // 여기에 새로운 테이블 타입이 추가될 때마다 case를 추가
+            _ => null
+        };
+    }
+
+    public T GetTable<T>(TableType type) where T : class, ITable
+    {
+        return _tables.TryGetValue(type, out var table) ? table as T : null;
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/Table/TableManager.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/Table/TableManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 848f7bcdfd2d69a49b783ba3bb320635

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/CurrencyChanger.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/CurrencyChanger.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CurrencyChanger : MonoBehaviour
+{
+    #region serialized fields
+
+    [SerializeField] private CurrencyUI _mainCurrencyUI;
+    [SerializeField] private List<CurrencyUI> _currencyUIs;
+
+    #endregion // serialized fields
+
+
+    #region unity funcs
+
+    private void Awake()
+    {
+        // 각 CurrencyUI 클릭 이벤트 연결
+        foreach (var ui in _currencyUIs) {
+            ui.OnCurrencyClicked = HandleCurrencyClicked;
+        }
+    }
+
+    #endregion // unity funcs
+
+
+    #region private funcs
+
+    private void HandleCurrencyClicked(CurrencyType clickedType)
+    {
+        // 메인 UI의 타입을 변경
+        _mainCurrencyUI.SetCurrencyType(clickedType);
+
+        //test code
+        CurrencyManager.Instance.Add(clickedType, new BigCurrency(50, 0));
+    }
+
+    #endregion // private funcs
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/CurrencyChanger.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/CurrencyChanger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39a45514a102dcd4eb8466ddb05cdcf3

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/ItemSlot.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/ItemSlot.cs
@@ -1,16 +1,67 @@
+using TMPro;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.UI;
 
 public class ItemSlot : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    [SerializeField] private Image _itemImage;
+    [SerializeField] private TMP_Text _itemAmount;
+
+    private ItemData _itemData;
+    private AsyncOperationHandle<Sprite>? _loadedHandle;
+
+    public void SetItem(ItemData itemData, int itemAmount = 1)
     {
-        
+        _itemData = itemData;
+
+        // 개수 텍스트
+        _itemAmount.text = FormatItemAmount(itemAmount);
+
+        // 아이콘 이미지 로드
+        LoadItemImage(_itemData.ImageKey);
     }
 
-    // Update is called once per frame
-    void Update()
+    private string FormatItemAmount(int amount)
     {
-        
+        if (amount <= 1) {
+            return string.Empty;
+        }
+
+        return "X" + amount.ToString();
+    }
+
+    private void LoadItemImage(string key)
+    {
+        ReleaseImageHandle(); // 기존 핸들 정리
+
+        if (string.IsNullOrEmpty(key)) {
+            Debug.LogWarning("[ItemSlot] ImageKey is empty");
+            return;
+        }
+
+        _loadedHandle = Addressables.LoadAssetAsync<Sprite>(key);
+        _loadedHandle.Value.Completed += handle => {
+            if (handle.Status == AsyncOperationStatus.Succeeded) {
+                _itemImage.sprite = handle.Result;
+            }
+            else {
+                Debug.LogWarning($"[ItemSlot] Failed to load sprite: {key}");
+            }
+        };
+    }
+
+    private void ReleaseImageHandle()
+    {
+        if (_loadedHandle.HasValue) {
+            Addressables.Release(_loadedHandle.Value);
+            _loadedHandle = null;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        ReleaseImageHandle();
     }
 }

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/PopupManager.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/PopupManager.cs
@@ -69,26 +69,42 @@ public class PopupManager : MonoBehaviour
 
     #region public funcs
 
-    public void ShowPopup(PopupType popupType, string message, Action onLeft = null, Action onRight = null)
+    public void ShowTooltip(ItemData item)
     {
-        if (!_popupDict.TryGetValue(popupType, out var popup) || popup == null) {
-            Debug.LogWarning($"[PopupManager] 등록되지 않은 팝업: {popupType}");
+        if (!_popupDict.TryGetValue(PopupType.Tooltip, out var uiBase) || uiBase == null) {
+            Debug.LogWarning("[PopupManager] Tooltip 팝업이 등록되지 않았습니다.");
             return;
         }
 
-        popup.SetShow();
-        Debug.Log($"[PopupManager] ShowPopup: {popupType}, Message: {message}");
-
-        // TODO: popup 내부에 message, 버튼 콜백 전달
-    }
-
-    public void ClosePopup(PopupType popupType)
-    {
-        if (_popupDict.TryGetValue(popupType, out var popup) && popup != null) {
-            popup.SetHide();
-            Debug.Log($"[PopupManager] ClosePopup: {popupType}");
+        if (uiBase is TootipPanel tooltipPanel) {
+            tooltipPanel.SetShow(item);
+            Debug.Log($"[PopupManager] ShowTooltip: {item.Name}");
+        }
+        else {
+            Debug.LogError("[PopupManager] PopupType.Tooltip 이 TooltipPanel이 아님");
         }
     }
+
+    //public void ShowPopup(PopupType popupType, string message, Action onLeft = null, Action onRight = null)
+    //{
+    //    if (!_popupDict.TryGetValue(popupType, out var popup) || popup == null) {
+    //        Debug.LogWarning($"[PopupManager] 등록되지 않은 팝업: {popupType}");
+    //        return;
+    //    }
+
+    //    popup.SetShow();
+    //    Debug.Log($"[PopupManager] ShowPopup: {popupType}, Message: {message}");
+
+    //    // TODO: popup 내부에 message, 버튼 콜백 전달
+    //}
+
+    //public void ClosePopup(PopupType popupType)
+    //{
+    //    if (_popupDict.TryGetValue(popupType, out var popup) && popup != null) {
+    //        popup.SetHide();
+    //        Debug.Log($"[PopupManager] ClosePopup: {popupType}");
+    //    }
+    //}
 
     public void CloseAllPopups()
     {

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/TootipPanel.cs
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/TootipPanel.cs
@@ -1,0 +1,19 @@
+using TMPro;
+using UnityEngine;
+
+public class TootipPanel : UIBase
+{
+    [SerializeField] private ItemSlot _itemSlot;
+    [SerializeField] private TMP_Text _itemName;
+    [SerializeField] private TMP_Text _itemExplane;
+
+
+    public void SetShow(ItemData itemData)
+    {
+        _itemSlot.SetItem(itemData);
+        _itemName.text = itemData.Name;
+        _itemExplane.text = itemData.Detail;
+
+        base.SetShow();
+    }
+}

--- a/Assets/PersonalWorkplace/BIK/Scripts/UI/TootipPanel.cs.meta
+++ b/Assets/PersonalWorkplace/BIK/Scripts/UI/TootipPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19ef546d7e89fa646a50737371957596

--- a/Assets/PersonalWorkplace/MSK/MSK_Scripts/HeroParty/Enum/Enums.cs
+++ b/Assets/PersonalWorkplace/MSK/MSK_Scripts/HeroParty/Enum/Enums.cs
@@ -63,4 +63,19 @@ public enum PopupType
 {
     OfflineRewardPopup,
     RewardPopup,
+    Tooltip,
+}
+
+public enum TableType
+{
+    Item,
+}
+
+public enum ItemType
+{
+    None,
+    Currency,
+    Box,
+    Equipment,
+    Etc
 }

--- a/Assets/Resources/CurrencyConfig.asset
+++ b/Assets/Resources/CurrencyConfig.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72d31b90e956efe47aa47215e8060561, type: 3}
+  m_Name: CurrencyConfig
+  m_EditorClassIdentifier: 
+  _entries:
+  - type: 0
+    itemId: 11001
+  - type: 1
+    itemId: 11002
+  - type: 2
+    itemId: 11003
+  - type: 3
+    itemId: 11004
+  - type: 4
+    itemId: 11005
+  - type: 5
+    itemId: 11006
+  - type: 6
+    itemId: 11009

--- a/Assets/Resources/CurrencyConfig.asset.meta
+++ b/Assets/Resources/CurrencyConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5911fb78ac549a54aba804cb3cc8dd53
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/TableConfig.asset
+++ b/Assets/Resources/TableConfig.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 144c2e9449d6432468d763183a70fb8c, type: 3}
+  m_Name: TableConfig
+  m_EditorClassIdentifier: 
+  _tables:
+  - type: 0
+    sheetUrl: https://docs.google.com/spreadsheets/d/1z0tBggvngyM38fD-EBo8NgECIpGGHtkU/export?format=csv&gid=780487655

--- a/Assets/Resources/TableConfig.asset.meta
+++ b/Assets/Resources/TableConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 932d58c441d2f2c4b948bb0f35e0ba86
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/DEMO_GameScene.unity
+++ b/Assets/Scenes/DEMO_GameScene.unity
@@ -355,55 +355,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a08a13190ab641459cbfb4ebf78e407, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &618849623
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 618849625}
-  - component: {fileID: 618849624}
-  m_Layer: 0
-  m_Name: GameLifetimeScope
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &618849624
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 618849623}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e21ba02a2e1313b4395d98f7e1c5c6f9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parentReference:
-    TypeName: 
-  autoRun: 1
-  autoInjectGameObjects:
-  - {fileID: 0}
---- !u!4 &618849625
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 618849623}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 165.1343, y: 797.6676, z: 2.0297072}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &903740305
 GameObject:
   m_ObjectHideFlags: 0
@@ -2252,7 +2203,6 @@ SceneRoots:
   - {fileID: 1501635565}
   - {fileID: 1353327468}
   - {fileID: 1702075909}
-  - {fileID: 618849625}
   - {fileID: 1424309458}
   - {fileID: 1557756084}
   - {fileID: 1611352872}

--- a/Assets/Scenes/IntroScene.unity
+++ b/Assets/Scenes/IntroScene.unity
@@ -1,0 +1,372 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &292679973
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 292679975}
+  - component: {fileID: 292679974}
+  m_Layer: 0
+  m_Name: IntroSceneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &292679974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292679973}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46cb4a93b28a4d74d97406648d27de0e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mainSceneName: DEMO_GameScene
+--- !u!4 &292679975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292679973}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 720, y: 1480, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1117035973
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1117035975}
+  - component: {fileID: 1117035974}
+  - component: {fileID: 1117035976}
+  m_Layer: 0
+  m_Name: GameLifetimeScope
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1117035974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1117035973}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e21ba02a2e1313b4395d98f7e1c5c6f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentReference:
+    TypeName: 
+  autoRun: 1
+  autoInjectGameObjects:
+  - {fileID: 0}
+--- !u!4 &1117035975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1117035973}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 165.1343, y: 797.6676, z: 2.0297072}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1117035976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1117035973}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a65a4d715b239d342836652866e50123, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1888448170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1888448173}
+  - component: {fileID: 1888448172}
+  - component: {fileID: 1888448171}
+  - component: {fileID: 1888448174}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1888448171
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888448170}
+  m_Enabled: 1
+--- !u!20 &1888448172
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888448170}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1888448173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888448170}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1888448174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1888448170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1888448173}
+  - {fileID: 1117035975}
+  - {fileID: 292679975}

--- a/Assets/Scenes/IntroScene.unity.meta
+++ b/Assets/Scenes/IntroScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70fa10ef7d48d9c4c82ad50165d20ef1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,9 +5,9 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: Assets/PersonalWorkplace/CMS/Scenes/CMS_Scene.unity
-    guid: f1d0daca3c965624fbc7b6f603a6712e
+  - enabled: 1
+    path: Assets/Scenes/IntroScene.unity
+    guid: 70fa10ef7d48d9c4c82ad50165d20ef1
   - enabled: 1
     path: Assets/Scenes/DEMO_GameScene.unity
     guid: 55e504d48f2ff774a87ecc6f23e1b2d3


### PR DESCRIPTION
의존성 주입 순서 문제 해결을 위한 IntroScene 추가

인트로씬에서 Firebase 초기화, 의존성 주입을 끝낸 후 메인씬으로 넘어가도록 수정

테이블을 서버에서 불러오도록 하는 코드 TableManager 추가

아이템 테이블 TItem 추가

테이블을 제작할 때 필수로 하는 함수를 구현한 인터페이스 ITable 추가

에디터에서 게임을 시작할 때 항상 IntroScene 에서 시작하게 하는 코드 PlayModeStartFromIntro 추가 // 체크로 해제 가능 툴 추가

상단 UI에 보여지는 재화를 바꾸는 코드 추가

상단 UI 상세창에서 이미지 클릭 시 해당 아이템 툴팁 표시하는 툴팁 팝업 추가

아이템 슬롯에 ItemData 가 들어가도록 수정