### PR TITLE
[Feat] PartyManager 배치 / 소환 로직 분리

### DIFF
--- a/Assets/PersonalWorkplace/KMS/Script/CurrencyDungeon/CurrencyDungeonPlayerSet.cs
+++ b/Assets/PersonalWorkplace/KMS/Script/CurrencyDungeon/CurrencyDungeonPlayerSet.cs
@@ -36,6 +36,7 @@ public class CurrencyDungeonPlayerSet : MonoBehaviour
             }
         }
     }
+
     private void CreateCards()
     {
         foreach ((string id, CardInfo info) data in playerData.currentPlayerDataList)
@@ -52,7 +53,8 @@ public class CurrencyDungeonPlayerSet : MonoBehaviour
     {
         foreach (GameObject card in cards)
         {
-            PartyManager.Instance.AddMember(card);
+            PartyManager.Instance.AddMember(card.GetComponent<HeroInfoSetting>().chardata);
+            // 기존 코드             PartyManager.Instance.AddMember(card);
         }
     }
 }

--- a/Assets/PersonalWorkplace/KMS/Script/CurrencyDungeon/LevelSelectPanel.cs
+++ b/Assets/PersonalWorkplace/KMS/Script/CurrencyDungeon/LevelSelectPanel.cs
@@ -87,13 +87,22 @@ public class LevelSelectPanel : MonoBehaviour
 
     public void GetCurrentPlayerDatas()
     {
+        /*  기존 코드입니다. 
+           playerData.currentPlayerDataList.Clear();
+           foreach (GameObject member in PartyManager.Instance.partyMembers)
+           {
+               HeroInfoSetting info = member.GetComponent<HeroInfoSetting>();
+               string id = info.HeroID;
+               CardInfo card = info.chardata;
+               playerData.currentPlayerDataList.Add((id, card));
+           }
+        */
+
         playerData.currentPlayerDataList.Clear();
-        foreach (GameObject member in PartyManager.Instance.partyMembers)
+        foreach (CardInfo member in PartyManager.Instance.partyMembers)
         {
-            HeroInfoSetting info = member.GetComponent<HeroInfoSetting>();
-            string id = info.HeroID;
-            CardInfo card = info.chardata;
-            playerData.currentPlayerDataList.Add((id, card));
+            string id = member.HeroID;
+            playerData.currentPlayerDataList.Add((id, member));
         }
     }
 

--- a/Assets/PersonalWorkplace/MSK/MSK_Scripts/HeroInfoSetting.cs
+++ b/Assets/PersonalWorkplace/MSK/MSK_Scripts/HeroInfoSetting.cs
@@ -128,16 +128,14 @@ public class HeroInfoSetting : MonoBehaviour
         //  파티를 편성중이라면
         if (PartyManager.Instance.IsHeroSetNow)
         {
-            if (!PartyManager.Instance.partyMembers.Contains(gameObject))
+            if (!PartyManager.Instance.partyMembers.Contains(chardata))
             {
-                PartyManager.Instance.AddMember(gameObject);
-                PartyManager.Instance.AddMemberID(heroID);
+                PartyManager.Instance.AddMember(chardata);
                 selectRoot.gameObject.SetActive(true);
             }
             else
             {
-                PartyManager.Instance.RemoveMember(gameObject);
-                PartyManager.Instance.RemoveMemberID(heroID);
+                PartyManager.Instance.RemoveMember(chardata);
                 selectRoot.gameObject.SetActive(false);
             }
         }

--- a/Assets/PersonalWorkplace/MSK/MSK_Scripts/UI/HeroUI.cs
+++ b/Assets/PersonalWorkplace/MSK/MSK_Scripts/UI/HeroUI.cs
@@ -20,7 +20,8 @@ public class HeroUI : UIBase
     [Header("Text")]
     [SerializeField] private TextMeshProUGUI PartyMembersCount;
 
-    public event Action partySetFin;
+    public event Action partySetFin;                    // 파티 편성 시작 알림
+    public event Action partySetStart;                  // 파티 편성 종료 알림
 
     #region Unity LifeCycle
 
@@ -75,6 +76,8 @@ public class HeroUI : UIBase
         heroSetSave.onClick.AddListener(OnClickHeroSetSave);
         heroSetEnd.onClick.AddListener(OnClickHeroSetEnd);
         autoSet.onClick.AddListener(OnClickAutoSet);
+        
+        partySetStart?.Invoke();
     }
 
 
@@ -91,7 +94,6 @@ public class HeroUI : UIBase
         autoSet.onClick.RemoveListener(OnClickAutoSet);
 
         PartyManager.Instance.EndPartySetting();    // 편성 종료
-        PartyManager.Instance.PartyInit();
 
         // 배치하기 버튼 활성화
         heroSet.gameObject.SetActive(true);


### PR DESCRIPTION
GameObject => CardInfo 전달받도록 변경됨
AddMember에서 소환하지 않고 PartyInit() 에서 소환을 한번에 진행